### PR TITLE
Fix bug where multiple countdown timers can run at once

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -9,6 +9,7 @@ let score_glad = score_mad = score = current_word = 0;
 let max_timer;
 let timer;
 let game_running = false;
+let countdown_interval;
 
 // Run the initialize function when the DOM is fully loaded
 document.addEventListener('DOMContentLoaded', initialize);
@@ -91,15 +92,18 @@ function resetGame() {
 }
 
 function startCountdown() {
+    // Stop any existing countdowns
+    clearInterval(countdown_interval);
+
     // Display the initial time
     document.getElementById('timer-display').textContent = `Time: ${timer}s`;
 
-    countdownInterval = setInterval(() => {
+    countdown_interval = setInterval(() => {
         timer--;
         document.getElementById('timer-display').textContent = `Time: ${timer}s`;
 
         if (timer <= 0) {
-            clearInterval(countdownInterval); // Stop the countdown
+            clearInterval(countdown_interval); // Stop the countdown
             game_running = false;
         }
     }, 1000); // Update every second


### PR DESCRIPTION
Prior to this commit, if a user reset the score, an additional countdown timer was created. This caused the time to count down twice as fast.

This commit clears any existing timers everytime a new one is started.

Fixes https://github.com/klrmngr/poetry-for-neanderthals/issues/16